### PR TITLE
Only show navigation buttons as needed when selectTabAfterScroll option is enabled

### DIFF
--- a/src/ts/jquery.ui.scrolltabs.ts
+++ b/src/ts/jquery.ui.scrolltabs.ts
@@ -249,8 +249,8 @@
         - this.$scrollDiv.outerWidth()) < 1);
 
       if (this.options.scrollOptions.selectTabAfterScroll) {
-        showLeft = !(this.options.active === 0);
-        showRight = (this.options.active + 1 === this.tabs.length) ? false : true;
+        showLeft = (this.options.active === 0) ? false : showLeft;
+        showRight = (this.options.active + 1 === this.tabs.length) ? false : showRight;
       }
 
       showLeft ? this.$leftArrowWrapper.addClass('stNavVisible')


### PR DESCRIPTION
Updated operation to only show navigation buttons when needed even (based on size) when scrollOptions.selectTabAfterScroll is enabled. This way for tab sets that are smaller than available width (or screen resizes), the navigations buttons do not always show.